### PR TITLE
fix loading on cpu

### DIFF
--- a/tracker/base_tracker.py
+++ b/tracker/base_tracker.py
@@ -29,7 +29,7 @@ class BaseTracker:
         with open("tracker/config/config.yaml", 'r') as stream: 
             config = yaml.safe_load(stream) 
         # initialise XMem
-        network = XMem(config, xmem_checkpoint).to(device).eval()
+        network = XMem(config, xmem_checkpoint, map_location=device).eval()
         # initialise IncerenceCore
         self.tracker = InferenceCore(network, config)
         # data transformation


### PR DESCRIPTION
Fixes 

> RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.