### PR TITLE
Change device from 'cuda:3' to 'cuda:0'

### DIFF
--- a/app.py
+++ b/app.py
@@ -378,7 +378,7 @@ SAM_checkpoint = download_checkpoint(sam_checkpoint_url, folder, sam_checkpoint)
 xmem_checkpoint = download_checkpoint(xmem_checkpoint_url, folder, xmem_checkpoint)
 e2fgvi_checkpoint = download_checkpoint_from_google_drive(e2fgvi_checkpoint_id, folder, e2fgvi_checkpoint)
 args.port = 12212
-args.device = "cuda:3"
+args.device = "cuda:0"
 # args.mask_save = True
 
 # initialize sam, xmem, e2fgvi models


### PR DESCRIPTION
The original repository was developed on a multi-GPU research setup.
Since Google Colab provides only a single GPU (cuda:0), I adapted the device configuration to make the code portable and runnable across environments.